### PR TITLE
detecting images with missing/blank depth data

### DIFF
--- a/libfovis/libfovis/motion_estimation.hpp
+++ b/libfovis/libfovis/motion_estimation.hpp
@@ -46,6 +46,13 @@ class MotionEstimator
                         const Eigen::Isometry3d &init_motion_est,
                         const Eigen::MatrixXd &init_motion_cov);
 
+    // added to enable a reset from the parent class (VisualOdometry)
+    // when there is no valid keypoints (due to missing depth data)
+    // Use very sparingly as it should not be exposed
+    void setMotionEstimateAsNoData() {
+      _estimate_status = NO_DATA;
+    }
+
     bool isMotionEstimateValid() const {
       return _estimate_status == SUCCESS;
     }

--- a/libfovis/libfovis/visual_odometry.cpp
+++ b/libfovis/libfovis/visual_odometry.cpp
@@ -187,6 +187,15 @@ VisualOdometry::processFrame(const uint8_t* gray, DepthSource* depth_source)
   // detect features in new frame
   _cur_frame->prepareFrame(gray, _fast_threshold, depth_source);
 
+  // added to detect when there are no valid keypoints
+  // this can occur if there is not any valid depth data (e.g. a blank depth image)
+  if(_cur_frame->getNumKeypoints() == 0) {
+    _estimator->setMotionEstimateAsNoData();
+    _change_reference_frames = true;
+    _frame_count = 0;
+    return;
+  }
+
   const CameraIntrinsicsParameters& input_camera = _rectification->getInputCameraParameters();
   int width = input_camera.width;
   int height = input_camera.height;


### PR DESCRIPTION
the Realsense camera produces occasional depth images with no data. this is turn will result in no keypoints being valid. previously this caused a nan to produced when estimating motion.

this patch detects there being no keypoints and resets the estimator to the original state.

NOTE: it resets the frame counter so that a completely new keyframes is created in the next iteration